### PR TITLE
fix(tests): add country field to physical spaces Company setup

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,8 +1,7 @@
 # Documento de Continuidad — condominium_management
 
-**Fecha:** 2026-05-22
-**Para:** Nueva sesión Claude Code abriendo este app en VS Code
-**Desde:** Sesión de migración v16 — infraestructura Claude cerrada
+**Fecha:** 2026-05-24
+**Sesión:** Campaña de tests v16 — Financial Management + Physical Spaces completados
 
 ---
 
@@ -18,32 +17,98 @@ comités, asambleas y contribuciones entre sitios (arquitectura multi-site).
 
 ---
 
-## Estado actual de migración
-
-La app está instalada en bench v16 y funcional. La migración v15 → v16 está en curso.
+## Estado actual
 
 | Ítem | Estado |
 |---|---|
-| Repo limpio en `main` | ✅ commit 220f7f5 |
-| Tag v15 preservado | ✅ `v15-last-before-v16-migration` |
 | `condo-v16.dev` | ✅ frappe 16.18.2 + erpnext 16.18.3 + condominium_management 0.0.1 |
-| `bench migrate` en condo-v16.dev | ✅ Limpio, sin errores |
-| 85 DocTypes instalados | ✅ Verificado post-install |
-| 27 Custom Fields en Company | ✅ Verificado |
-| 22 Roles custom | ✅ Verificados |
-| `test-condominium.localhost` | ⏳ Pendiente de crear |
-| Setup wizard / Company base | ⏳ Pendiente — esperar test site |
-| Tests en v16 | ⏳ Pendiente — esperar test site |
+| `bench migrate` en condo-v16.dev | ✅ Limpio |
+| `test-condominium.localhost` | ✅ Creado y funcional con `allow_tests: true` |
+| Seed en test site | ✅ Warehouse Types (Transit, Finished Goods, Raw Material, Work In Progress) + `_Test Company` (_TC, México, MXN) |
+| Tests Financial Management | ✅ 458/458 OK (L1+L2+L3+L4 real+L4 TypeC), 9 skipped (database_schema deuda técnica) |
+| Tests Physical Spaces | ✅ 31/31 OK — todos los 4 DocTypes con tests cubiertos |
+| Tests Committee Management | ⏳ Pendiente |
+| Tests Companies | ⏳ Pendiente |
+| Tests Document Generation | ⏳ Pendiente |
+| Tests Dashboard Consolidado | ⏳ Pendiente |
+| Tests Community Contributions | ⏳ Pendiente |
+| Tests API Documentation System | ⏳ Pendiente |
 
 ---
 
-## PRs ya mergeados en main
+## PRs mergeados en main
 
 | PR | Descripción |
 |---|---|
 | #29 | ADRs y documentos rescatados de branches históricas |
 | #30 | Fixture de 22 roles custom |
 | #31 | Filtros explícitos para evitar contaminación de fixture export |
+| #32 | Infraestructura Claude v16 (CLAUDE.md, CONTINUITY.md, .claude/commands symlink) |
+
+## PR abierto — pendiente de merge
+
+| PR | Branch | Descripción |
+|---|---|---|
+| #33 (abierto) | `feature/fix-physical-spaces-tests-v16` | Fix: `country` en setUp de tests Physical Spaces para ERPNext v16 |
+
+---
+
+## Campaña de tests completada
+
+### Financial Management — 458/458 OK
+
+| Nivel | Tests | Skipped | Estado |
+|---|---|---|---|
+| L1 field validation | 107 | 0 | ✅ |
+| L2 business logic | 130 | 0 | ✅ |
+| L3 integration | 152 | 0 | ✅ |
+| L4 real (59 archivos) | 59 | 9 | ✅ |
+| L4 Type C (10 archivos) | 10 | 0 | ✅ |
+
+Excluidos deliberadamente: `credit_balance_management_l4_database_schema` (SQL con nombre de tabla en minúsculas) + 63 Type B ficticios/simulados.
+
+### Physical Spaces — 31/31 OK
+
+| Archivo | Tests | Estado |
+|---|---|---|
+| `test_space_category` | 7 | ✅ |
+| `test_component_type` | 10 | ✅ |
+| `test_physical_space` | 6 | ✅ |
+| `test_space_component` | 8 | ✅ |
+
+DocTypes sin tests: `allowed_child_category`, `allowed_parent_category`.
+
+---
+
+## Issues técnicos pendientes / deuda de testing
+
+| # | Descripción | Acción recomendada |
+|---|---|---|
+| I-1 | Todos los `_l4_database_schema` de FM usan `DESCRIBE \`tab{lowercase}\`` → skipean universalmente | Corregir nombre de tabla en 10 archivos |
+| I-2 | `credit_balance_management_l4_database_schema` — mismo problema, excluido explícitamente | Incluir en fix de I-1 |
+| I-3 | 63 archivos Type B simulados/ficticios existen en repo e inflan conteo CI | Decisión: eliminar, mover o marcar skip explícito |
+
+---
+
+## Qué NO tocar
+
+| Qué | Por qué |
+|---|---|
+| `admin1.dev` y sites v15 | Entorno de producción en desarrollo — no modificar BD |
+| ISSUE #7 — hooks universales | `hooks.py` líneas 190-198 comentados por razón documentada |
+| Registro `User` en Entity Type Configuration | Decisión pendiente — no eliminar sin autorización |
+| 55 registros de test en BD v15 | Limpieza pendiente con backup previo |
+| `master_template_registry.last_update` | Campo volátil — puede contaminar fixtures |
+| BD de cualquier site | Ningún `UPDATE`/`INSERT`/`DELETE` sin autorización explícita |
+
+---
+
+## Próximo paso recomendado
+
+**Siguiente módulo recomendado: Companies o Committee Management.**
+
+- **Companies** (23 DocTypes): alto valor — involucra custom fields sobre el DocType `Company` de ERPNext y hooks activos en `company_hooks.py`. Validar que la integración con ERPNext v16 no introdujo regresiones.
+- **Committee Management** (21 DocTypes, el más grande): conviene inventariar sus archivos de test antes de iniciar, para estimar el esfuerzo y detectar dependencias.
 
 ---
 
@@ -53,109 +118,24 @@ La app está instalada en bench v16 y funcional. La migración v15 → v16 está
 1. /home/erpnext/Developer/frappe-infrastructure/.claude/CLAUDE.md  ← reglas globales del ecosistema
 2. /home/erpnext/frappe-bench-v16/.claude/CLAUDE.md                 ← contexto del bench v16
 3. /home/erpnext/frappe-bench-v16/apps/condominium_management/CLAUDE.md  ← este app
+4. Este archivo: CONTINUITY.md
+5. PRs recientes: gh pr list --state all --limit 10
 ```
 
-Los 3 son obligatorios antes de tocar nada.
-
 ---
 
-## Cómo abrir Claude Code correctamente para este app
-
-**Este app vive en bench v16. Abrir VS Code desde el directorio correcto:**
+## Comandos frecuentes
 
 ```bash
-cd /home/erpnext/frappe-bench-v16/apps/condominium_management
-code .
-```
+# Tests (site autorizado)
+bench --site test-condominium.localhost run-tests --module <MODULE> --lightmode
 
-Verificar entorno al inicio de sesión:
-
-```bash
-cd /home/erpnext/frappe-bench-v16
-which bench        # debe ser /home/erpnext/frappe-bench-v16/env/bin/bench
-node --version     # debe ser v24.x
-echo $VIRTUAL_ENV  # debe ser /home/erpnext/frappe-bench-v16/env
-```
-
-**Si `which bench` apunta a `/home/erpnext/frappe-bench/env/bin/bench` — STOP.**
-Estás en entorno v15 heredado. Cerrar la ventana y abrir desde bench v16.
-
----
-
-## Qué NO tocar
-
-| Qué | Por qué |
-|---|---|
-| `admin1.dev` y sites v15 | Entorno de producción en desarrollo — no modificar BD |
-| ISSUE #7 — hooks universales | `hooks.py` líneas 190-198 comentados por razón documentada. Ver `docs/development/issue7-hooks-universales-contexto.md` |
-| Registro `User` en Entity Type Configuration | Decisión pendiente — no eliminar sin autorización |
-| 55 registros de test en BD v15 | Limpieza pendiente con backup previo |
-| `master_template_registry.last_update` | Campo volátil — puede contaminar fixtures si no se filtra |
-| BD de cualquier site | Ningún `UPDATE`/`INSERT`/`DELETE` sin autorización explícita |
-
----
-
-## Contexto de branches históricas
-
-Estas branches contienen trabajo previo sin mergear. No borrar sin análisis:
-
-- `feature/financial-management` y variantes
-- `feature/committee-management-clean`
-- `feature/document-generation-framework`
-- `feature/community-contributions-cross-site`
-- `feature/physical-spaces`, `feature/companies-module`
-- `release/v1.0.0`
-
-El estado del código en `main` es el baseline válido post-auditoría.
-
----
-
-## Próximo paso recomendado
-
-**Crear `test-condominium.localhost`** — site aislado de tests en bench v16.
-
-El patrón es idéntico a `facturacion_mexico`:
-- Un site dev: `condo-v16.dev` (ya existe)
-- Un site test: `test-condominium.localhost` (pendiente)
-
-Secuencia para crear el test site (requiere autorización explícita):
-
-```bash
-cd /home/erpnext/frappe-bench-v16
-
-# 1. Crear site (requiere MariaDB root password — el usuario lo corre)
-bench new-site test-condominium.localhost --admin-password admin
-
-# 2. Instalar ERPNext
-bench --site test-condominium.localhost install-app erpnext
-
-# 3. Instalar la app
-bench --site test-condominium.localhost install-app condominium_management
-
-# 4. Habilitar tests
-bench --site test-condominium.localhost set-config allow_tests true
-
-# 5. Verificar
-bench --site test-condominium.localhost list-apps
-```
-
-Después del test site: setup mínimo en `condo-v16.dev` (Company base) y luego tests.
-
----
-
-## Comandos de trabajo frecuentes
-
-```bash
 # Desarrollo
 bench --site condo-v16.dev migrate
 bench --site condo-v16.dev export-fixtures --app condominium_management
 bench build --app condominium_management
 
-# Tests (una vez creado test-condominium.localhost)
-bench --site test-condominium.localhost run-tests --app condominium_management
-
 # Diagnóstico (read-only)
-bench --site condo-v16.dev list-apps
-bench --site condo-v16.dev mariadb --execute "SELECT ..."
+bench --site test-condominium.localhost list-apps
 bench list-sites
 ```

--- a/condominium_management/physical_spaces/doctype/physical_space/test_physical_space.py
+++ b/condominium_management/physical_spaces/doctype/physical_space/test_physical_space.py
@@ -15,7 +15,8 @@ class TestPhysicalSpace(FrappeTestCase):
 					"doctype": "Company",
 					"company_name": "Test Condominium",
 					"abbr": "TC",
-					"default_currency": "USD",
+					"default_currency": "MXN",
+					"country": "Mexico",
 				}
 			).insert()
 

--- a/condominium_management/physical_spaces/doctype/space_component/test_space_component.py
+++ b/condominium_management/physical_spaces/doctype/space_component/test_space_component.py
@@ -15,7 +15,8 @@ class TestSpaceComponent(FrappeTestCase):
 					"doctype": "Company",
 					"company_name": "Test Company",
 					"abbr": "TCOMP",
-					"default_currency": "USD",
+					"default_currency": "MXN",
+					"country": "Mexico",
 				}
 			).insert()
 


### PR DESCRIPTION
## Objetivo

Corregir dos tests de Physical Spaces que fallaban en ERPNext v16 al intentar crear una Company sin el campo `country`, que es obligatorio en v16.

## Cambios principales

- `test_physical_space.py`: agrega `country="Mexico"` y cambia `default_currency` a `"MXN"` en `setUp`
- `test_space_component.py`: misma corrección en `setUp`

## Validaciones realizadas

Tests ejecutados en `test-condominium.localhost`:

| Archivo | Tests | Resultado |
|---|---|---|
| `test_physical_space` | 6/6 | ✅ OK |
| `test_space_component` | 8/8 | ✅ OK |
| `test_space_category` (control) | 7/7 | ✅ OK |
| `test_component_type` (control) | 10/10 | ✅ OK |
| **Physical Spaces total** | **31/31** | ✅ |

## Fuera de alcance

- No toca código funcional ni controllers
- No toca fixtures
- No toca BD v15 ni admin1.dev
- No incluye `one_offs/validate_install.py`

## Riesgos / pendientes

- Sin riesgos: cambio mínimo en archivos de test únicamente
- `allowed_child_category` y `allowed_parent_category` no tienen tests — fuera de scope de este PR