### PR TITLE
fix(physical_spaces): clean up space code generation and hierarchy fields

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,85 +1,82 @@
 # CONTINUITY.md — condominium_management
 
-**Fecha:** 2026-05-29
-**Rama activa:** `feature/docs-new-workflow`
-**Tarea actual:** Ejecutando /ship commit — dos commits separados en progreso
+**Fecha:** 2026-05-30
+**Rama activa:** `fix/billing-cycle-field-references`
+**Tarea actual:** Commit de Physical Space fixes — financial_management rechazado y en pausa
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Cierre de la implementación de Property Declared Owner + limpieza de Property Registry.
-Dos commits listos para ejecutar, luego PR hacia main.
+Correcciones de Physical Space (space_code, space_level, referencias de jerarquía).
+El bloque financiero fue detenido por rechazo arquitectónico del diseño actual.
 
 Plan que estoy siguiendo:
-`docs_new/arquitectura/property_registry_ownership_mvp.md` — v1.1 ya actualizado.
+Auditoría histórica del app completada esta sesión. Ver decisiones vigentes abajo.
 
 Objetivo inmediato:
-Ejecutar commit 1 (Property Registry / Declared Owner) → commit 2 (Property Account) → PR.
+Hacer PR de los cambios de Physical Space. Luego decidir qué hacer con financial_management.
 
 Criterio de avance:
-Dos commits creados + git status limpio + PR abierto.
+PR abierto con solo cambios de Physical Spaces + financial_management sin tocar.
 
 ---
 
 ## Estado actual
 
 ### Ya cerrado
-- Space Category v1 + docs Physical Spaces commiteados (`b1f62e3`) ✅
-- Property Declared Owner implementado (rename completo desde Property Copropiedad) ✅
-- Property Registry limpio (23 campos obsoletos eliminados) ✅
-- Patches: `remove_property_registry_deprecated_fields` + `migrate_property_copropiedad_to_declared_owner` ✅
-- bench migrate limpio en test-condominium.localhost y condo-v16.dev ✅
-- Tests: 4/4 + 12/12 + 11/11 OK post-linter ✅
-- Validación GUI completada en condo-v16.dev ✅
+- PR #35: Property Registry limpio + Property Declared Owner ✅
+- Physical Space: space_code read_only, space_level hidden, building/floor/zone hidden, código consecutivo `<abbr>-####` ✅
+- Validación GUI Physical Space completada en condo-v16.dev ✅
 
 ### En progreso
-- /ship commit — preparando commit 1 y commit 2
+- Commit de Physical Space fixes (en curso)
 
 ### Pendiente inmediato
-1. Commit 1: `feat(companies): implement declared owners and clean property registry`
-2. Commit 2: `feat(financial): add billing relationship type to property account`
-3. PR hacia main
+1. PR de Physical Space fixes
+2. Decisión arquitectónica sobre financial_management (requiere documento de diseño aprobado)
+3. Limpiar rama: los archivos de financial_management modificados en esta rama deben revertirse o moverse
 
 ### No repetir
-- No hacer DROP TABLE tabProperty Copropiedad hasta validar PR mergeado
+- No commitear financial_management sin documento de arquitectura aprobado primero
+- No parchear financial_management con fieldnames sin resolver el diseño de Property Account
+- No DROP TABLE tabProperty Copropiedad sin autorización
 - No reactivar ISSUE #7 (hooks universales)
-- No agregar tower/floor/unit_number a Property Registry
 - No commitear one_offs/
-- No tocar Billing Cycle / Fee Structure (tienen deuda de ownership_percentage preexistente)
 
 ---
 
 ## Decisiones vigentes
-- Property Registry = expediente de unidad privativa. Dirección/compliance/seguros → Company.
-- `tabProperty Copropiedad` conservada como respaldo hasta PR mergeado — sin DROP todavía.
-- `total_copropiedades_percentage` sigue en BD como columna legacy; `current_owners_total_percentage` es la activa.
-- Tests usan `UnitTestCase` / `IntegrationTestCase` (Frappe 16) — no `FrappeTestCase` deprecado.
-- `billing_cycle.py:382` y `fee_structure.py:201` leen `ownership_percentage`/`area_sqm` inexistentes — deuda preexistente, fuera de alcance.
+- Financial Management rechazado arquitectónicamente. Property Account tiene current_balance manual (reqd=1), billing config por cuenta, sistema paralelo a ERPNext. No se toca hasta tener documento de rediseño.
+- Physical Space: NO es Tree DocType (decisión explícita — permite jerarquía libre). space_code = document name via make_autoname por company abbr.
+- building_reference / floor_reference / zone_reference: ocultos y read_only. No se auto-calculan en MVP. Decisión: calcular desde jerarquía cuando haya caso de uso real.
+- Fee Structure (financial): diseño correcto, conservar.
+- billing_cycle.py y fee_structure.py tienen referencias a campos inexistentes — deuda conocida, no tocar hasta rediseño.
 
 ---
 
 ## Archivos relevantes ahora
 
 ### Leer primero
-- `docs_new/arquitectura/property_registry_ownership_mvp.md` — decisiones v1.1
+- `docs_new/tecnico/deuda-tecnica.md` — deuda técnica registrada
+- `condominium_management/financial_management/` — modificaciones rechazadas pendientes de revertir
 
 ### Probablemente editar
-- `CONTINUITY.md` — post-PR
+- `CONTINUITY.md` — al iniciar próxima tarea
 
 ### No tocar
 - `hooks.py` líneas ~190-198 — ISSUE #7
-- `financial_management/doctype/billing_cycle/` y `fee_structure/`
-- Sites v15
+- `financial_management/doctype/billing_cycle/` y `fee_structure/` — deuda de fieldnames
+- `financial_management/doctype/property_account/` — diseño rechazado
 
 ---
 
 ## Riesgos / cuidados
-- `billing_cycle.py:382` y `fee_structure.py:201` fallarán cuando se active cálculo real de cuotas.
-- Space Category Capa 1: validación con usuario no-Administrator aún pendiente.
+- La rama tiene modificaciones de financial_management que NO deben ir a PR. Deben revertirse antes de abrir PR.
+- `tabProperty Copropiedad` en BD: conservar hasta validación post-PR.
 
 ---
 
 ## Información faltante
-- Número de PR (aún no creado)
+- Decisión: ¿se revierte financial_management en esta rama o se crea branch separado para el rediseño?

--- a/condominium_management/physical_spaces/doctype/physical_space/physical_space.json
+++ b/condominium_management/physical_spaces/doctype/physical_space/physical_space.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "allow_rename": 1,
+ "allow_rename": 0,
  "autoname": "field:space_code",
  "creation": "2025-07-07 00:00:00.000000",
  "default_view": "List",
@@ -51,6 +51,7 @@
    "fieldname": "space_code",
    "fieldtype": "Data",
    "label": "Código del Espacio",
+   "read_only": 1,
    "unique": 1
   },
   {
@@ -95,7 +96,8 @@
   {
    "fieldname": "space_level",
    "fieldtype": "Int",
-   "label": "Nivel",
+   "hidden": 1,
+   "label": "Nivel de Jerarquía",
    "read_only": 1
   },
   {
@@ -111,20 +113,26 @@
   {
    "fieldname": "building_reference",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Edificio",
-   "options": "Physical Space"
+   "options": "Physical Space",
+   "read_only": 1
   },
   {
    "fieldname": "floor_reference",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Piso",
-   "options": "Physical Space"
+   "options": "Physical Space",
+   "read_only": 1
   },
   {
    "fieldname": "zone_reference",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Zona",
-   "options": "Physical Space"
+   "options": "Physical Space",
+   "read_only": 1
   },
   {
    "fieldname": "dimensions_section",
@@ -189,7 +197,7 @@
  "issingle": 0,
  "istable": 0,
  "max_attachments": 0,
- "modified": "2025-07-07 00:00:00.000000",
+ "modified": "2026-05-30 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Physical Spaces",
  "name": "Physical Space",

--- a/condominium_management/physical_spaces/doctype/physical_space/physical_space.py
+++ b/condominium_management/physical_spaces/doctype/physical_space/physical_space.py
@@ -22,20 +22,12 @@ class PhysicalSpace(Document):
 		self.generate_component_inventory_codes()
 
 	def generate_space_code(self):
-		"""Generar código único del espacio si no existe"""
+		"""Generar código único del espacio usando series por company."""
 		if not self.space_code:
-			# Generar código basado en nombre y timestamp
-			import re
-			import unicodedata
+			from frappe.model.naming import make_autoname
 
-			# Normalizar texto removiendo acentos
-			normalized = unicodedata.normalize("NFD", self.space_name)
-			ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
-
-			# Crear código base
-			base_code = re.sub(r"[^A-Za-z0-9]", "", ascii_text)[:10].upper()
-			timestamp = frappe.utils.cstr(frappe.utils.now_datetime().strftime("%m%d%H%M"))
-			self.space_code = f"{base_code}-{timestamp}"
+			abbr = frappe.db.get_value("Company", self.company, "abbr") or "ESP"
+			self.space_code = make_autoname(f"{abbr}-.####")
 
 	def validate_hierarchy(self):
 		"""Validaciones críticas para jerarquía híbrida"""

--- a/condominium_management/physical_spaces/doctype/physical_space/test_physical_space.py
+++ b/condominium_management/physical_spaces/doctype/physical_space/test_physical_space.py
@@ -2,10 +2,10 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestPhysicalSpace(FrappeTestCase):
+class TestPhysicalSpace(UnitTestCase):
 	def setUp(self):
 		"""Configurar datos de prueba"""
 		# Crear company de prueba si no existe
@@ -134,15 +134,15 @@ class TestPhysicalSpace(FrappeTestCase):
 		self.assertIn(apto.name, children)
 
 	def test_space_code_generation(self):
-		"""Test generación automática de código"""
+		"""Código generado automáticamente con formato <abbr>-<####>."""
 		space = frappe.get_doc(
 			{"doctype": "Physical Space", "space_name": "Área Común Piscina", "company": "Test Condominium"}
 		)
 		space.insert()
 
-		# Verificar que se generó código
 		self.assertTrue(space.space_code)
-		self.assertIn("AREACOMUN", space.space_code)
+		# Formato esperado: TC-0001, TC-0002, etc. (abbr de "Test Condominium" = TC)
+		self.assertRegex(space.space_code, r"^TC-\d{4}$")
 
 	def tearDown(self):
 		"""Limpiar datos de prueba"""

--- a/condominium_management/physical_spaces/hooks_handlers/space_validation.py
+++ b/condominium_management/physical_spaces/hooks_handlers/space_validation.py
@@ -14,9 +14,6 @@ def validate(doc, method):
 		# Validar categoría si está configurada
 		validate_category_requirements(doc)
 
-		# Validar referencias de ubicación
-		validate_location_references(doc)
-
 	except Exception as e:
 		frappe.log_error(f"Error en validación de Physical Space: {e!s}")
 		raise
@@ -109,22 +106,6 @@ def validate_category_hierarchy(doc, category):
 					f"La categoría '{category.category_name}' no puede ser hija de "
 					f"la categoría '{parent_doc.space_category}'"
 				)
-
-
-def validate_location_references(doc):
-	"""Validar referencias de ubicación física"""
-	# Validar que las referencias existen y están activas
-	references = [("building_reference", "Edificio"), ("floor_reference", "Piso"), ("zone_reference", "Zona")]
-
-	for field, label in references:
-		ref_value = getattr(doc, field, None)
-		if ref_value:
-			try:
-				ref_doc = frappe.get_doc("Physical Space", ref_value)
-				if not ref_doc.is_active:
-					frappe.throw(f"La referencia de {label} '{ref_value}' no está activa")
-			except frappe.DoesNotExistError:
-				frappe.throw(f"La referencia de {label} '{ref_value}' no existe")
 
 
 def validate_cost_center(doc):


### PR DESCRIPTION
## Objetivo

Limpiar el DocType Physical Space para que space_code sea inmutable, los campos 
de jerarquía sean correctos y el formulario no exponga campos innecesarios al usuario.

## Cambios principales

- space_code autogenerado y read_only — formato consecutivo <abbr>-#### por company 
  via make_autoname (ej: CV16-0001). Antes usaba timestamp (ej: TORREA-05301423).
- allow_rename=0 — evita renombrar el document name después de creado.
- building_reference / floor_reference / zone_reference: ocultos y read_only. 
  No se auto-calculan (MVP). No se usan en ningún query ni reporte.
- space_level oculto — calculado internamente, no aporta al usuario en el form.
- parent_space se mantiene como jerarquía oficial (no se convierte a Tree DocType).
- validate_location_references() eliminado de space_validation.py — código muerto 
  ya que los campos de referencia son siempre vacíos con hidden+read_only.
- test_physical_space.py migrado a UnitTestCase (patrón Frappe 16).
- Assertion de space_code actualizada para el nuevo formato consecutivo.

## Validaciones realizadas

- bench migrate: OK en condo-v16.dev
- TestPhysicalSpace: 6/6 OK
- ruff check: OK
- ruff format: OK
- GUI validation completada en condo-v16.dev:
  - space_level ya no aparece en el formulario
  - building/floor/zone no aparecen como captura manual
  - nuevo Physical Space genera código CV16-#### consecutivo
  - formulario guarda sin traceback
  - Property Registry sigue pudiendo seleccionar Physical Space

## Fuera de alcance

- financial_management no incluido (congelado, requiere rediseño arquitectónico)
- Space Component y Component Type no tocados (decisión CMMS pendiente)
- Document Generation no tocado
- Physical Space no se convierte a Tree DocType (decisión explícita)

## Riesgos / pendientes

- Space Category Capa 2 (bloqueo técnico contra usuario Administrator) pendiente.
  Solo Capa 1 implementada — allow_rename=0 + permisos read-only en DocType.
- building_reference / floor_reference / zone_reference permanecen en schema como
  campos ocultos. Auto-calcular desde jerarquía queda para cuando haya caso de uso real.