### PR TITLE
feat(ci): restore GitHub Actions CI for Frappe v16 with limited scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,135 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: condominium_management-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Server
+
+    services:
+      redis-cache:
+        image: redis:alpine
+        ports:
+          - 13000:6379
+      redis-queue:
+        image: redis:alpine
+        ports:
+          - 11000:6379
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mariadb-admin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+          --health-start-period=30s
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Setup Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install MariaDB client
+        run: sudo apt-get update && sudo apt-get install -y mariadb-client
+
+      - name: Init bench (Frappe v16)
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: |
+            pip install frappe-bench
+            bench init \
+              --skip-redis-config-generation \
+              --skip-assets \
+              --python "$(which python)" \
+              --frappe-branch version-16 \
+              ~/frappe-bench
+            mariadb --host 127.0.0.1 --port 3306 -u root -proot \
+              -e "SET GLOBAL character_set_server = 'utf8mb4'"
+            mariadb --host 127.0.0.1 --port 3306 -u root -proot \
+              -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+
+      - name: Install apps and create test site
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 25
+          max_attempts: 3
+          command: |
+            cd ~/frappe-bench
+            bench get-app --branch version-16 erpnext
+            bench get-app condominium_management $GITHUB_WORKSPACE
+            bench setup requirements --dev
+            bench new-site \
+              --db-root-password root \
+              --admin-password admin \
+              test.localhost
+            bench --site test.localhost install-app erpnext
+            bench --site test.localhost install-app condominium_management
+            bench --site test.localhost migrate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable test mode
+        working-directory: ~/frappe-bench
+        run: |
+          bench --site test.localhost set-config allow_tests true
+          bench --site test.localhost set-config developer_mode true
+
+      - name: Tests — physical_spaces
+        working-directory: ~/frappe-bench
+        run: |
+          bench --site test.localhost run-tests \
+            --app condominium_management \
+            --module condominium_management.physical_spaces
+
+      - name: Tests — dashboard_consolidado
+        working-directory: ~/frappe-bench
+        run: |
+          bench --site test.localhost run-tests \
+            --app condominium_management \
+            --module condominium_management.dashboard_consolidado
+
+      - name: Tests — community_contributions
+        working-directory: ~/frappe-bench
+        run: |
+          bench --site test.localhost run-tests \
+            --app condominium_management \
+            --module condominium_management.community_contributions
+
+      - name: Tests — api_documentation_system
+        working-directory: ~/frappe-bench
+        run: |
+          bench --site test.localhost run-tests \
+            --app condominium_management \
+            --module condominium_management.api_documentation_system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
           python-version: '3.14'
           cache: pip
 
-      - name: Setup Node 18
+      - name: Setup Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Cache yarn
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,36 +59,42 @@ jobs:
         with:
           node-version: 18
 
+      - name: Cache yarn
+        uses: actions/cache@v4
+        with:
+          path: ~/.yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+
       - name: Install MariaDB client
         run: sudo apt-get update && sudo apt-get install -y mariadb-client
 
+      # Step 1: bench init (frappe only, not retried — retry would hit "already exists")
       - name: Init bench (Frappe v16)
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          command: |
-            pip install frappe-bench
-            bench init \
-              --skip-redis-config-generation \
-              --skip-assets \
-              --python "$(which python)" \
-              --frappe-branch version-16 \
-              ~/frappe-bench
-            mariadb --host 127.0.0.1 --port 3306 -u root -proot \
-              -e "SET GLOBAL character_set_server = 'utf8mb4'"
-            mariadb --host 127.0.0.1 --port 3306 -u root -proot \
-              -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+        timeout-minutes: 20
+        run: |
+          pip install frappe-bench
+          bench init \
+            --skip-redis-config-generation \
+            --skip-assets \
+            --python "$(which python)" \
+            --frappe-branch version-16 \
+            ~/frappe-bench
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot \
+            -e "SET GLOBAL character_set_server = 'utf8mb4'"
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot \
+            -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
+      # Step 2: install apps + site (retriable, bench dir already exists so init is skipped)
       - name: Install apps and create test site
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 25
+          timeout_minutes: 20
           max_attempts: 3
           command: |
             cd ~/frappe-bench
-            bench get-app --branch version-16 erpnext
-            bench get-app condominium_management $GITHUB_WORKSPACE
+            bench get-app --branch version-16 --skip-assets erpnext
+            bench get-app --skip-assets condominium_management $GITHUB_WORKSPACE
             bench setup requirements --dev
             bench new-site \
               --db-root-password root \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,34 +107,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable test mode
-        working-directory: ~/frappe-bench
+        working-directory: /home/runner/frappe-bench
         run: |
           bench --site test.localhost set-config allow_tests true
           bench --site test.localhost set-config developer_mode true
 
       - name: Tests — physical_spaces
-        working-directory: ~/frappe-bench
+        working-directory: /home/runner/frappe-bench
         run: |
           bench --site test.localhost run-tests \
             --app condominium_management \
             --module condominium_management.physical_spaces
 
       - name: Tests — dashboard_consolidado
-        working-directory: ~/frappe-bench
+        working-directory: /home/runner/frappe-bench
         run: |
           bench --site test.localhost run-tests \
             --app condominium_management \
             --module condominium_management.dashboard_consolidado
 
       - name: Tests — community_contributions
-        working-directory: ~/frappe-bench
+        working-directory: /home/runner/frappe-bench
         run: |
           bench --site test.localhost run-tests \
             --app condominium_management \
             --module condominium_management.community_contributions
 
       - name: Tests — api_documentation_system
-        working-directory: ~/frappe-bench
+        working-directory: /home/runner/frappe-bench
         run: |
           bench --site test.localhost run-tests \
             --app condominium_management \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.12
+      - name: Setup Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: pip
 
       - name: Setup Node 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     strategy:
       fail-fast: false
     name: Server
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     services:
       redis-cache:

--- a/condominium_management/committee_management/default_positions.py
+++ b/condominium_management/committee_management/default_positions.py
@@ -74,6 +74,11 @@ def setup_positions_for_all_condo_companies():
 	Solo añade cargos que no existen. No modifica ni elimina existentes.
 	Idempotente — seguro de llamar múltiples veces.
 	"""
+	# company_type is a custom field added via fixtures.
+	# On fresh installs, the column may not exist yet when after_migrate runs.
+	if not frappe.db.has_column("Company", "company_type"):
+		return
+
 	condo_companies = frappe.get_all(
 		"Company",
 		filters={"company_type": "CONDO"},


### PR DESCRIPTION
## Objetivo

Reactivar el workflow de CI para `condominium_management` en GitHub Actions, actualizado a Frappe/ERPNext v16 y con alcance limitado para recuperar una base verde de pruebas.

## Contexto

El workflow anterior estaba deshabilitado como `ci.yml.disabled` y apuntaba a Frappe/ERPNext v15. El app actualmente trabaja sobre v16, por lo que reactivarlo sin cambios fallaría.

## Cambios

- Crea `.github/workflows/ci.yml` activo.
- Mantiene `.github/workflows/ci.yml.disabled` intacto como referencia histórica.
- Actualiza stack CI a:
  - Python 3.12
  - Node 18
  - MariaDB 10.6
  - Redis
  - Frappe `version-16`
  - ERPNext `version-16`
- Ejecuta `bench run-tests` con scope limitado.

## Tests incluidos en esta fase

- `condominium_management.physical_spaces`
- `condominium_management.dashboard_consolidado`
- `condominium_management.community_contributions`
- `condominium_management.api_documentation_system`

## Fuera de alcance

- `financial_management`: congelado, contiene tests obsoletos/ficticios.
- `committee_management`: en transición, varios tests apuntan a DocTypes legacy.
- `document_generation`: congelado por ISSUE #7.
- Limpieza de tests existentes.

## Riesgos conocidos

- `community_contributions` podría requerir contexto multi-site.
- `dashboard_consolidado` podría requerir datos auxiliares.
- La rama `version-16` de Frappe/ERPNext puede instalar una versión distinta a la local.
- Si alguna dependencia de GitHub Actions falla por deprecación, se ajustará en seguimiento.

## Validación local

Se validó que `bench run-tests --app condominium_management --module condominium_management.physical_spaces` es aceptado por Frappe v16. En Frappe v16 la salida detallada puede ir a `frappe.testing.log`; el exit code es la señal principal para CI.