### PR TITLE
docs(companies): document catalog policy and service contract level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,10 +133,11 @@ Sistema de administración de condominios sobre ERPNext. Gestiona propiedades, f
 
 ## Fixtures
 
-13 archivos en `condominium_management/fixtures/`, todos activos en `hooks.py`:
-- `custom_field.json` — 27 custom fields en Company
+14 archivos en `condominium_management/fixtures/`, todos activos en `hooks.py`:
+- `companies_custom_field.json` — 27 custom fields en Company (4 secciones: Condominio, Administración, Legal, Financiero)
+- `custom_field.json` — 74 custom fields en Event (Committee Meeting + Assembly + Community Event)
 - `role.json` — 22 roles custom
-- Catálogos: policy_category, contribution_category, compliance_requirement_type, document_template_type, jurisdiction_level, property_status_type, property_usage_type, acquisition_type, company_type, enforcement_level, entity_type_configuration, master_template_registry
+- Catálogos (HQ/globales y con extensión local posible): ver `hooks.py` § POLÍTICA DE CATÁLOGOS y `docs/adr/0002-catalog-hq-policy.md`
 
 **72 DocTypes sin fixtures** — instalación nueva queda sin datos de referencia para la mayoría de módulos.
 
@@ -180,6 +181,12 @@ Muchos L4 Type B son ficticios y no prueban funcionalidad real. Tests reales baj
 - [ ] Patch creado si hay cambios de esquema con datos
 - [ ] `bench --site condo-v16.dev migrate` limpio
 - [ ] Ver checklist global en `frappe-infrastructure/CONTRIBUTING.md`
+
+## Notas operativas para Claude
+
+- **Aislamiento multi-condominio:** User Permissions por Company están DIFERIDAS al PR del portal (Fase 3 de PUA). Los DocTypes operativos tienen `company` requerido, pero la restricción de visibilidad no está activa aún.
+- **Service Management Contract:** usa `client_condominium` (no `company`) — es intencional. Ver `docs/adr/0003-service-management-contract-level.md`.
+- **Catálogos:** ver `docs/adr/0002-catalog-hq-policy.md` para la política HQ vs extensión local.
 
 ---
 

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,92 +1,71 @@
 # CONTINUITY.md — condominium_management
 
 **Fecha:** 2026-06-06
-**Rama activa:** `feature/condominium-people-phase1`
-**Tarea actual:** Listo para Commit 2 — Condominium People Phase 1 (PUA + tests 14/14 OK)
+**Rama activa:** `feature/companies-permissions-and-catalog-policy`
+**Tarea actual:** Commit autorizado — Fases 3/4 Companies listas para commitear
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-Commit 2 de la rama `feature/condominium-people-phase1`: módulo Condominium People Phase 1.
-Commit 1 ya está en la rama (fix Companies/Property Registry, `cb351e4`).
+PR de Fases 3/4 del plan Companies/Property Registry: permisos para Physical Space y
+Condominium Information + política de catálogos HQ documentada en ADRs.
 
 Plan que estoy siguiendo:
-- `working_docs/active/PLAN_companies_property_registry_alignment.md` (Fases 1+2A ✅)
-- `working_docs/active/ARCH_condominium-people-authorization.md` v4 (PUA)
+`working_docs/active/PLAN_companies_property_registry_alignment.md` — Fases 3/4 completadas
 
 Objetivo inmediato:
-Ejecutar Commit 2 con el mensaje aprobado → luego abrir PR.
+Commit → push → PR → merge.
 
 Criterio de avance:
-Dos commits en la rama → PR hacia main.
+Commit creado con el mensaje aprobado → PR abierto hacia main.
 
 ---
 
 ## Estado actual
 
-### Ya cerrado (en rama, no mergeado)
-- **Commit 1** `cb351e4` — fix(companies): restore Company custom fields fixture and require physical_space
-  - `companies_custom_field.json` (27 campos Company)
-  - `custom_field.json` actualizado (74 Event)
-  - `physical_space: reqd: 1` en Property Registry
-  - `validate_physical_space_company()` en property_registry.py
-  - tests actualizados + test_install.py
-  - plan working_docs actualizado
+### Ya mergeado a main
+- PR #40 — Companies fixture fix + Condominium People Phase 1
 
-### Listo para Commit 2 (tests 14/14 OK en test-condominium.localhost)
-- `hooks.py` — `setup_property_relationship_types` en after_migrate
-- `modules.txt` — "Condominium People"
-- `condominium_people/` — módulo completo: Property Relationship Type + PUA + utils + setup
-- `test_property_user_authorization.py` — 14 tests, UnitTestCase, todos pasan
-- `working_docs/active/ARCH_condominium-people-authorization.md`
+### Listo para commit (rama actual)
+- `physical_space.json` — +Property Administrator (R/W/C), +Condominium Manager (R/W/C), +Property Manager (R)
+- `condominium_information.json` — +Property Administrator (R/W/C)
+- `hooks.py` — política catálogos HQ inline
+- `docs/adr/0002-catalog-hq-policy.md` — nuevo ADR
+- `docs/adr/0003-service-management-contract-level.md` — nuevo ADR
+- `mkdocs.yml` — sección ADR en nav (0000-0003 todos referenciados)
+- `CLAUDE.md` — reducido a notas operativas, refs a ADRs
+- `PLAN_companies_property_registry_alignment.md` — Fases 3/4 marcadas completas
 
 ### Pendiente inmediato
-1. Ejecutar Commit 2 con mensaje aprobado
-2. Abrir PR hacia main
+1. Ejecutar commit con mensaje aprobado
+2. Push → PR
 
 ### No repetir
-- No usar git commit directo — siempre /ship commit
-- No usar reqd:1 con depends_on en Custom Fields — usar mandatory_depends_on
-- No commitear master_template_registry.json si solo cambió last_update
-- Frappe v16 export-fixtures sobreescribe cuando hay dos entradas para el mismo DocType — usar `prefix`
-- No hacer unique sobre physical_space aún — diferido (bodegas/cajones)
-- FrappeTestCase dispara generación de test records que falla en test-condominium.localhost — usar UnitTestCase
+- No poner análisis de decisiones en `CLAUDE.md` — van en `docs/adr/`
+- No duplicar en CLAUDE.md lo que ya está en ADRs o working_docs
+- El warning de `mkdocs-redirects` no instalado localmente es deuda preexistente
 
 ---
 
 ## Decisiones vigentes
-- `physical_space: reqd: 1` activo en Property Registry
-- `unique` sobre `physical_space` DIFERIDO — análisis de unidades accesorias pendiente
-- Service Management Contract = Nivel 1/2 Domika↔Condominio (D2 cerrado)
-- Catálogos sin company = maestros HQ/globales (D3 cerrado)
-- Property Copropiedad = congelada/deprecated, no eliminar
-- PUA unicidad `user + property_registry` para MVP (D2)
-- PUA módulo propio `condominium_people` (D5)
-- User Permissions sync DIFERIDO a Fase 3 (portal) — los helpers funcionan sin ellas
-- Financial Management y Property Account: NO tocar (congelados)
-- Committee Poll, Voting System: bloqueados hasta que PUA esté mergeado
-- Fases 3/4 del plan Companies (permisos Physical Space, catálogos) = PR separado posterior
+- User Permissions por Company DIFERIDAS al PR del portal (Fase 3 PUA)
+- `unique` sobre `physical_space` DIFERIDO (bodegas/cajones)
+- SMC = Nivel 1/2 Domika↔Condominio (docs/adr/0003)
+- Catálogos HQ policy (docs/adr/0002)
+- Financial Management, Property Account: congelados
+- Committee Poll: desbloqueado, siguiente PR
 
 ---
 
 ## Archivos relevantes ahora
 
-### Leer primero
+### Para este commit
+- `docs/adr/0002-catalog-hq-policy.md`
+- `docs/adr/0003-service-management-contract-level.md`
 - `working_docs/active/PLAN_companies_property_registry_alignment.md`
-- `working_docs/active/ARCH_condominium-people-authorization.md`
-
-### Para el PR (después del Commit 2)
-- `condominium_people/utils.py` — helpers de autorización
-- `condominium_people/setup.py` — defaults idempotentes
 
 ### No tocar
 - `financial_management/` — congelado
-- `fixtures/master_template_registry.json` — solo revertir last_update si export lo toca
-
----
-
-## Riesgos / cuidados
-- Fases 3/4 de Companies (permisos Physical Space, catálogos documentados) pendientes de PR separado
-- `working_docs/active/ARCH_*` incluido en Commit 2 — es parte del entregable de arquitectura
+- `one_offs/` — nunca se commitean

--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -2,24 +2,24 @@
 
 **Fecha:** 2026-06-06
 **Rama activa:** `feature/companies-permissions-and-catalog-policy`
-**Tarea actual:** Commit autorizado — Fases 3/4 Companies listas para commitear
+**Tarea actual:** PR #41 abierto — esperando merge; bench update pendiente
 
 ---
 
 ## Recuperación rápida
 
 Estoy trabajando en:
-PR de Fases 3/4 del plan Companies/Property Registry: permisos para Physical Space y
-Condominium Information + política de catálogos HQ documentada en ADRs.
+PR #41 con Fases 3/4 del plan Companies/Property Registry (permisos + ADRs).
+El usuario va a correr `bench update` en el bench v16.
 
 Plan que estoy siguiendo:
-`working_docs/active/PLAN_companies_property_registry_alignment.md` — Fases 3/4 completadas
+`working_docs/active/PLAN_companies_property_registry_alignment.md` — Fases 1-4 completadas
 
 Objetivo inmediato:
-Commit → push → PR → merge.
+Merge del PR #41 → sync-check post-merge → decidir siguiente trabajo (Committee Poll).
 
 Criterio de avance:
-Commit creado con el mensaje aprobado → PR abierto hacia main.
+PR #41 mergeado a main → rama limpia.
 
 ---
 
@@ -28,44 +28,49 @@ Commit creado con el mensaje aprobado → PR abierto hacia main.
 ### Ya mergeado a main
 - PR #40 — Companies fixture fix + Condominium People Phase 1
 
-### Listo para commit (rama actual)
-- `physical_space.json` — +Property Administrator (R/W/C), +Condominium Manager (R/W/C), +Property Manager (R)
-- `condominium_information.json` — +Property Administrator (R/W/C)
-- `hooks.py` — política catálogos HQ inline
-- `docs/adr/0002-catalog-hq-policy.md` — nuevo ADR
-- `docs/adr/0003-service-management-contract-level.md` — nuevo ADR
-- `mkdocs.yml` — sección ADR en nav (0000-0003 todos referenciados)
-- `CLAUDE.md` — reducido a notas operativas, refs a ADRs
-- `PLAN_companies_property_registry_alignment.md` — Fases 3/4 marcadas completas
+### En progreso (PR #41 — abierto)
+- `physical_space.json` — +Property Administrator, +Condominium Manager, +Property Manager
+- `condominium_information.json` — +Property Administrator
+- `docs/adr/0002-catalog-hq-policy.md` — política catálogos HQ
+- `docs/adr/0003-service-management-contract-level.md` — SMC = Nivel 1/2
+- `mkdocs.yml` — sección ADR en nav
+- `hooks.py` — política catálogos inline
+- `PLAN_*.md` — Fases 3/4 cerradas
 
 ### Pendiente inmediato
-1. Ejecutar commit con mensaje aprobado
-2. Push → PR
+1. Merge PR #41
+2. sync-check post-merge
+3. Decidir siguiente: Committee Poll con validación PUA
 
 ### No repetir
-- No poner análisis de decisiones en `CLAUDE.md` — van en `docs/adr/`
-- No duplicar en CLAUDE.md lo que ya está en ADRs o working_docs
-- El warning de `mkdocs-redirects` no instalado localmente es deuda preexistente
+- No poner análisis arquitectónicos en `CLAUDE.md` — van en `docs/adr/`
+- Antes de bench update: verificar que las apps tengan commits pendientes resueltos
+- FrappeTestCase dispara record generation — usar UnitTestCase en test site
 
 ---
 
 ## Decisiones vigentes
-- User Permissions por Company DIFERIDAS al PR del portal (Fase 3 PUA)
+- User Permissions por Company DIFERIDAS al PR del portal
 - `unique` sobre `physical_space` DIFERIDO (bodegas/cajones)
-- SMC = Nivel 1/2 Domika↔Condominio (docs/adr/0003)
-- Catálogos HQ policy (docs/adr/0002)
-- Financial Management, Property Account: congelados
-- Committee Poll: desbloqueado, siguiente PR
+- SMC = Nivel 1/2 → `docs/adr/0003`
+- Catálogos HQ policy → `docs/adr/0002`
+- Financial Management congelado
+- Committee Poll desbloqueado — siguiente PR
 
 ---
 
 ## Archivos relevantes ahora
 
-### Para este commit
-- `docs/adr/0002-catalog-hq-policy.md`
-- `docs/adr/0003-service-management-contract-level.md`
+### Leer primero
 - `working_docs/active/PLAN_companies_property_registry_alignment.md`
+- `working_docs/active/ARCH_condominium-people-authorization.md`
 
 ### No tocar
 - `financial_management/` — congelado
 - `one_offs/` — nunca se commitean
+
+---
+
+## Riesgos / cuidados
+- `mkdocs build` bloqueado localmente por `mkdocs-redirects` no instalado — deuda preexistente, no de este PR
+- Tras bench update: verificar que `bench migrate` corra limpio en condo-v16.dev y test-condominium.localhost

--- a/condominium_management/companies/doctype/condominium_information/condominium_information.json
+++ b/condominium_management/companies/doctype/condominium_information/condominium_information.json
@@ -150,6 +150,13 @@
    "read": 1,
    "write": 1,
    "create": 1
+  },
+  {
+   "role": "Property Administrator",
+   "permlevel": 0,
+   "read": 1,
+   "write": 1,
+   "create": 1
   }
  ]
 }

--- a/condominium_management/hooks.py
+++ b/condominium_management/hooks.py
@@ -341,9 +341,6 @@ fixtures = [
 		"filters": [["name", "in", ["Service Management Contract"]]],
 	},  # ✅ ENABLED (2026-05-21) - Filtro explícito. Registro 'User' excluido hasta decisión humana
 	#     sobre si es configuración funcional o artefacto de desarrollo.
-	"Company Type",  # ✅ ENABLED - Autoname normalizado (name == type_code)
-	"Acquisition Type",  # ✅ ENABLED - required_documents poblado via one-off script
-	"Policy Category",  # ✅ ENABLED - 15 categorías profesionales completas
 	# "User Type",                    # ❌ ELIMINADO (2025-10-26) - DocType legacy que hacía override incorrecto de Frappe core
 	#                                   # Sin implementación real (0 referencias código), conflicto arquitectónico (duplica Roles)
 	#                                   # DocType nativo Frappe restaurado. Ver commit para detalles completos.
@@ -367,15 +364,27 @@ fixtures = [
 	# ============================================================================
 	# HABILITADOS - Fixtures válidos listos para migrar (13/14)
 	# ============================================================================
-	# Companies Module Masters - Solo fixtures verificados como válidos
-	"Property Usage Type",  # ✅ VÁLIDO - Cosmético (5 registros íntegros: Residencial, Comercial, Mixto, Industrial, Oficinas)
-	"Property Status Type",  # ✅ VÁLIDO - Cosmético (6 registros íntegros: Activo, Inactivo, En Venta, En Arriendo, En Construcción, Abandonado)
-	"Enforcement Level",  # ✅ VÁLIDO - Cosmético (4 registros íntegros)
-	"Document Template Type",  # ✅ VÁLIDO - Cosmético (registros íntegros)
-	"Jurisdiction Level",  # ✅ VÁLIDO - Cosmético (4 registros íntegros)
-	"Compliance Requirement Type",  # ✅ VÁLIDO - Cosmético (5 registros íntegros)
-	# Physical Spaces Module Masters — catálogo controlado del app (no editar manualmente)
-	"Space Category",  # ✅ ENABLED - 51 categorías precargadas para condominios residencial y uso mixto
+	#
+	# POLÍTICA DE CATÁLOGOS — Regla D3 (aprobada 2026-06-06)
+	# -------------------------------------------------------
+	# Maestros HQ/globales: catálogos sin campo `company`. Se instalan via fixtures.
+	# Aplican a todos los condominios. No se modifican por condominio.
+	# Extensión local posible (marcada abajo): el condominio puede agregar registros
+	# propios, pero solo cuando sea explícitamente necesario y aprobado.
+	# Ver: working_docs/active/PLAN_companies_property_registry_alignment.md § FASE 4
+	#
+	# Companies Module Masters - Maestros HQ/globales
+	"Company Type",  # HQ — tipos de empresa (Condominio, Administradora, etc.)
+	"Acquisition Type",  # HQ — tipos de adquisición; required_documents poblado via one-off
+	"Property Usage Type",  # HQ — tipos de uso (Residencial, Comercial, Mixto, Industrial, Oficinas)
+	"Property Status Type",  # HQ — estados de propiedad (Activo, Inactivo, En Venta, etc.)
+	"Enforcement Level",  # HQ — niveles de enforcement
+	"Document Template Type",  # HQ — tipos de documento
+	"Jurisdiction Level",  # HQ — niveles jurisdiccionales
+	"Compliance Requirement Type",  # HQ — tipos de requisito legal
+	"Policy Category",  # HQ con extensión local posible — categorías de política; condominio puede agregar propias
+	# Physical Spaces Module Masters
+	"Space Category",  # HQ con extensión local posible — 51 categorías base; condominio puede ampliar
 	# Sistema de Roles custom del sistema (22 roles requeridos por DocType permissions)
 	{
 		"dt": "Role",

--- a/condominium_management/physical_spaces/doctype/physical_space/physical_space.json
+++ b/condominium_management/physical_spaces/doctype/physical_space/physical_space.json
@@ -215,6 +215,42 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Property Administrator",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Condominium Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Property Manager",
+   "share": 0,
+   "write": 0
   }
  ],
  "quick_entry": 1,

--- a/docs/adr/0002-catalog-hq-policy.md
+++ b/docs/adr/0002-catalog-hq-policy.md
@@ -1,0 +1,53 @@
+# ADR-0002: Política de catálogos — Maestros HQ vs extensión local
+
+**Fecha:** 2026-06-06
+**Estado:** Aceptado
+**Autor:** Luis Montanaro / Claude Code
+**Contexto:** Auditoría Companies/Property Registry — Fase 4
+
+---
+
+## Contexto
+
+El módulo Companies define una serie de catálogos de referencia (tipos de uso, estados de propiedad, tipos de adquisición, etc.) que se instalan via fixtures. Estos catálogos no tienen campo `company` — aplican a toda la instalación. Se necesitaba una política explícita para saber cuándo un catálogo puede ser modificado por condominio y cuándo no.
+
+---
+
+## Decisión
+
+Los catálogos sin campo `company` son **maestros HQ/globales**. Se instalan via fixtures de la app y aplican a todos los condominios sin excepción. No se modifican por condominio individual.
+
+**Maestros HQ (no modificables por condominio):**
+
+| Catálogo | Descripción |
+|---|---|
+| `Company Type` | Tipos de empresa (Condominio, Administradora, etc.) |
+| `Acquisition Type` | Tipos de adquisición de propiedad |
+| `Property Usage Type` | Tipos de uso (Residencial, Comercial, Mixto, etc.) |
+| `Property Status Type` | Estados de propiedad (Activo, Inactivo, En Venta, etc.) |
+| `Enforcement Level` | Niveles de enforcement |
+| `Document Template Type` | Tipos de documento |
+| `Jurisdiction Level` | Niveles jurisdiccionales |
+| `Compliance Requirement Type` | Tipos de requisito legal |
+
+**Maestros HQ con extensión local posible** (el condominio puede agregar registros propios, pero solo cuando sea explícitamente necesario):
+
+| Catálogo | Razón |
+|---|---|
+| `Policy Category` | 19 categorías estándar; un condominio puede necesitar categorías propias |
+| `Space Category` | 51 categorías base; un condominio puede necesitar categorías adicionales |
+
+---
+
+## Consecuencias
+
+- Los fixtures de catálogos HQ se instalan en cada `bench migrate` y no se sobreescriben con datos locales.
+- Si un condominio necesita variantes propias en el futuro, el catálogo migra a un modelo con campo `company` opcional (global = sin company, local = con company). Ese cambio requiere ADR nuevo.
+- La extensión local en `Policy Category` y `Space Category` se hace agregando registros nuevos — nunca modificando los HQ existentes.
+- Los comentarios en `hooks.py` § POLÍTICA DE CATÁLOGOS documentan esta regla inline.
+
+---
+
+## Alternativas consideradas
+
+**Catálogos configurables por condominio desde el inicio:** cada catálogo con campo `company` opcional. Descartado por complejidad innecesaria — ningún condominio real ha solicitado variantes propias. El modelo puede evolucionar cuando haya caso concreto.

--- a/docs/adr/0003-service-management-contract-level.md
+++ b/docs/adr/0003-service-management-contract-level.md
@@ -1,0 +1,40 @@
+# ADR-0003: Service Management Contract — DocType Nivel 1/2 (Domika↔Condominio)
+
+**Fecha:** 2026-06-06
+**Estado:** Aceptado
+**Autor:** Luis Montanaro / Claude Code
+**Contexto:** Auditoría Companies/Property Registry — Fase 3
+
+---
+
+## Contexto
+
+`Service Management Contract` usa `client_condominium (Link → Company)` como campo de aislamiento, en lugar del campo convencional `company` que usan todos los DocTypes operativos del módulo Companies. Esta desviación fue detectada durante la auditoría y requería una decisión explícita.
+
+En la arquitectura Domika, el sistema opera en tres niveles:
+- **Nivel 1:** HQ / Domika (la empresa administradora)
+- **Nivel 2:** Condominio cliente (la Company que representa el edificio)
+- **Nivel 3:** Unidades y personas del condominio
+
+---
+
+## Decisión
+
+`Service Management Contract` es un DocType de **Nivel 1/2**: modela el contrato entre Domika (administradora) y el condominio cliente. No es un DocType operativo interno del condominio.
+
+Por tanto, usar `client_condominium` en lugar de `company` es correcto y no debe cambiarse. Este DocType representa la relación comercial entre empresas, no un documento de operación del condominio.
+
+---
+
+## Consecuencias
+
+- `Service Management Contract` no debe seguir la convención de campo `company` que aplica a DocTypes operativos.
+- Filtros automáticos de Frappe por `company` no aplican a este DocType — es intencional.
+- Los informes y dashboards que filtran por `company` no deben incluir `Service Management Contract` como DocType operativo del condominio.
+- Si en el futuro se necesita un contrato interno de servicios dentro de un condominio, se crea un DocType nuevo separado que sí sigue la convención `company`.
+
+---
+
+## Alternativas consideradas
+
+**Renombrar a `company`:** haría que SMC se comporte como DocType operativo del condominio. Descartado — semánticamente incorrecto. SMC modela la relación entre dos companies (Domika y el cliente), no un documento interno del condominio.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,11 @@ nav:
       - CI/CD: development/workflows/ci-cd.md
       - Troubleshooting: development/workflows/troubleshooting.md
       - Documentation Maintenance: development/workflows/documentation-maintenance.md
+  - Decisiones (ADR):
+    - ADR-0000 Estado pre-migración: adr/0000-estado-real-pre-migracion.md
+    - ADR-0001 Reconciliación branches: adr/0001-branch-reconciliation-before-v16.md
+    - ADR-0002 Política catálogos HQ: adr/0002-catalog-hq-policy.md
+    - ADR-0003 Service Management Contract: adr/0003-service-management-contract-level.md
   - Referencia:
     - README: reference/README.md
   - Changelog: changelog/CHANGELOG.md

--- a/working_docs/active/PLAN_companies_property_registry_alignment.md
+++ b/working_docs/active/PLAN_companies_property_registry_alignment.md
@@ -381,12 +381,43 @@ Agregar comentario en `hooks.py` junto a cada fixture declarando su tipo. No mod
 
 ---
 
-## Próximas fases (no iniciadas)
+## Fase 3 — Completada (2026-06-06)
 
-- **Fase 3** — Permisos: Physical Space (agregar Property Administrator/Property Manager/Condominium Manager), Condominium Information (agregar Property Administrator)
-- **Fase 4** — Solo documentación de regla HQ/global en hooks.py
+**Physical Space** — permisos agregados en `physical_space.json`:
+- `Property Administrator`: R/W/C, sin delete
+- `Condominium Manager`: R/W/C, sin delete
+- `Property Manager`: R solamente
+
+**Condominium Information** — permisos agregados en `condominium_information.json`:
+- `Property Administrator`: R/W/C, sin delete
+
+**User Permissions automáticas:** DIFERIDAS al PR del portal condominial. Documentado en `CLAUDE.md` + `docs/adr/0003-*`.
+
+**Service Management Contract:** sin cambios de código. Decisión D2 documentada en `docs/adr/0003-service-management-contract-level.md`.
+
+---
+
+## Fase 4 — Completada (2026-06-06)
+
+**Catálogos HQ (Regla D3):**
+- `docs/adr/0002-catalog-hq-policy.md` — decisión permanente documentada
+- `hooks.py` § POLÍTICA DE CATÁLOGOS — comentarios inline
+- `mkdocs.yml` — sección ADR agregada al nav (ADR-0000 a ADR-0003)
+- `CLAUDE.md` — referencia breve, sin duplicar análisis
+
+---
+
+## Pendientes explícitos (fuera de este PR)
+
+| Pendiente | Bloqueante | PR esperado |
+|---|---|---|
+| User Permissions automáticas por Company | No (solo portal) | PR portal condominial (Fase 3 PUA) |
+| `unique` sobre `physical_space` | No | Requiere análisis bodegas/cajones primero |
+| Vínculo Unidad↔Customer (Property Account) | No | PR Financial Management (congelado) |
+| Committee Poll con validación PUA | No | Próximo PR |
+| Eliminar `Property Copropiedad` DocType | No | PR limpieza técnica |
 
 ---
 
 *Fin del plan.*
-*Estado: Fases 1 + 2A implementadas · No commitear sin autorización.*
+*Estado: Fases 1, 2A, 3 y 4 completadas · bench migrate pendiente · commit pendiente autorización.*


### PR DESCRIPTION
## Objetivo

Cerrar las Fases 3 y 4 del plan Companies/Property Registry: permisos operativos para administradores del condominio y documentación formal de decisiones arquitectónicas en ADRs.

## Cambios principales

**Permisos operativos (Fase 3)**
- `Physical Space`: agrega Property Administrator (R/W/C), Condominium Manager (R/W/C), Property Manager (R). Antes solo System Manager podía gestionar espacios físicos.
- `Condominium Information`: agrega Property Administrator (R/W/C). Antes solo System Manager y Company Administrator.
- User Permissions automáticas por Company: diferidas al PR del portal condominial (Fase 3 PUA). Documentado en `CLAUDE.md`.
- Service Management Contract: sin cambios de código; decisión documentada en ADR-0003.

**Documentación arquitectónica (Fase 4)**
- `docs/adr/0002-catalog-hq-policy.md` — Política de catálogos HQ/globales vs extensión local. Los catálogos sin campo `company` son maestros HQ que aplican a todos los condominios.
- `docs/adr/0003-service-management-contract-level.md` — Service Management Contract es DocType Nivel 1/2 (Domika↔Condominio). El campo `client_condominium` es correcto e intencional.
- `mkdocs.yml` — Sección "Decisiones (ADR)" agregada al nav, incluyendo ADR-0000 a ADR-0003 (los dos ADRs anteriores no tenían entrada en el nav).
- `hooks.py` § POLÍTICA DE CATÁLOGOS — documentación inline de la regla HQ.
- `CLAUDE.md` — reducido a notas operativas breves con referencias a ADRs; el análisis completo está en los ADRs.

**Plan activo**
- `working_docs/active/PLAN_companies_property_registry_alignment.md` — Fases 3 y 4 marcadas como completadas. Tabla de pendientes explícitos agregada.

## Validaciones realizadas

- `bench --site condo-v16.dev migrate` — limpio.
- Permisos verificados en BD: `DocPerm` para Physical Space (4 roles) y Condominium Information (3 roles).
- Los 3 roles utilizados existen en fixtures con `desk_access: 1`.
- Todos los archivos referenciados en `mkdocs.yml` nav existen en disco.
- `ruff check` + `ruff format` en `hooks.py`: sin errores.

## Fuera de alcance

- User Permissions automáticas por Company (diferido al portal)
- `unique` sobre `physical_space` (diferido — análisis bodegas/cajones)
- Financial Management / Property Account (congelados)
- Committee Poll (próximo PR)
- `Property Copropiedad` deprecation limpieza (deuda técnica conocida)

## Riesgos / pendientes

- `mkdocs build` está bloqueado localmente por el plugin `mkdocs-redirects` no instalado. Es deuda preexistente no introducida por este PR.
- Los pendientes del plan quedan formalmente documentados en `working_docs/active/PLAN_*.md`.

**Requiere:** `bench migrate` al instalar.